### PR TITLE
FIX Use check_file_exists()

### DIFF
--- a/scripts/cms-any/license.php
+++ b/scripts/cms-any/license.php
@@ -41,10 +41,9 @@ $licenseFilename = 'LICENSE';
 foreach (['LICENSE.md', 'license.md', 'license'] as $filename) {
     rename_file_if_exists($filename, $licenseFilename);
 }
-
 // only update licence contents if module is on silverstripe account
 if (module_account() === 'silverstripe') {
-    if (file_exists('LICENSE')) {
+    if (check_file_exists($licenseFilename)) {
         $oldContents = read_file($licenseFilename);
         $newContents = str_replace('SilverStripe', 'Silverstripe', $oldContents);
         if ($newContents !== $oldContents) {

--- a/tests/ScriptsTest.php
+++ b/tests/ScriptsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class ScriptsTest extends TestCase
+{
+    /**
+     * This is a weird unit-test as it's essentially linting, though it's useful to ensure that the scripts are valid
+     * 
+     * Ensure that file_exists() isn't used any scripts as it it's a native PHP function that does not use $MODULE_DIR
+     * Instead you need to use check_file_exists() which does use $MODULE_DIR
+     */
+    public function testNoFileExists()
+    {
+        $scripts = glob(__DIR__ . '/../scripts/**/*.php');
+        foreach ($scripts as $script) {
+            $contents = file_get_contents($script);
+            $found = (bool) preg_match('#(?<!check_)file_exists\(#', $contents);
+            $this->assertFalse($found, "Script $script has file_exists() in it, use check_file_exists() instead");
+        }
+        // need at least one assertion or phpunit says this is a risky test
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/91

Note use of file_exists() in license.php did not result in any existing licenses being erroneously overwritten in any of the previous PRs in https://github.com/silverstripe/.github/issues/85 or https://github.com/silverstripe/gha-merge-up/issues/4 (I manually checked)