### PR TITLE
NEW Update issue/PR templates on default branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,32 +41,39 @@ MS_GITHUB_TOKEN=abc123 php run.php update --cms-major=5 --branch=next-minor --dr
 | Flag | Description |
 | ---- | ------------|
 | --cms-major=[version] | The major version of CMS to use (default: 5) |
-| --branch=[type] | The branch type to use - next-minor\|next-patch (default: next-patch) |
-| --only=[modules] | Only include the specified modules (without account prefix) separated by commas e.g. silverstripe-config,silverstripe-assets |
-| --exclude=[modules] | Exclude the specified modules (without account prefix) separated by commas e.g. silverstripe-mfa,silverstripe-totp |
+| --branch=[type] | The branch type to use - `next-minor`\|`next-patch`\|`github-default` (default: `next-patch`) |
+| --only=[modules] | Only include the specified modules (without account prefix) separated by commas e.g. `silverstripe-config,silverstripe-assets` |
+| --exclude=[modules] | Exclude the specified modules (without account prefix) separated by commas e.g. `silverstripe-mfa,silverstripe-totp` |
 | --dry-run | Do not push to github or create pull-requests |
 | --account | GitHub account to use for creating pull-requests (default: creative-commoners) |
-| --no-delete | Do not delete _data and _modules directories before running |
+| --no-delete | Do not delete `_data` and `modules` directories before running |
 | --update-prs | Update existing open PRs instead of creating new PRs |
+
+**Note** that using `--branch=github-default` will only run scripts in the `scripts/default-branch` directory.
 
 ## GitHub API secondary rate limit
 
-You may hit a secondary GitHub rate limit because this tool may create too many pull-requests in a short space of time. 
-To help with this the tool will always output the urls of all pull-requests updated and also the repos that were 
+You may hit a secondary GitHub rate limit because this tool may create too many pull-requests in a short space of time.
+To help with this the tool will always output the urls of all pull-requests updated and also the repos that were
 updated so you can add them to the --exclude flag on subsequent re-runs.
 
 ## Adding new scripts
 
-Simply add new scripts to either `scripts/cms-<version>` to run on a specific cms-major or `scripts/cms-any` to run 
-on any cms-major and they will be automatically picked up and run when the tool is run. Code in the script will be 
+### Where to add your script
+
+- `scripts/cms-<version>` to run on a specific cms-major
+- `scripts/cms-any` to run on any cms-major
+- `scripts/default-branch` to only run on the default branch in GitHub
+
+Scripts will be automatically picked up and run when the tool is run. Code in the script will be
 passed through `eval()` on the module that is currently being processed.
 
-Make use of functions in `funcs_scripts.php` such as `write_file_if_not_exist()` and `read_file()` to access the 
+Make use of functions in `funcs_scripts.php` such as `write_file_if_not_exist()` and `read_file()` to access the
 correct files in the module that is currently being processed and also to ensure that console output is consistent.
 
 Do not use functions in `funcs_utils.php` as they are not intended to be used in scripts.
 
-Scripts will be automatically wrapped in an anoymous function so you do not need to worry about variables crossing 
+Scripts will be automatically wrapped in an anoymous function so you do not need to worry about variables crossing
 over into different scripts.
 
 ## Updating the tool when a new major version of CMS is updated

--- a/funcs_scripts.php
+++ b/funcs_scripts.php
@@ -133,6 +133,18 @@ function is_module()
 }
 
 /**
+ * Determine if the module being processed is a source of documentation
+ *
+ * Example usage:
+ * is_docs()
+ */
+function is_docs()
+{
+    $moduleName = module_name();
+    return $moduleName === 'developer-docs' || $moduleName === 'silverstripe-userhelp-content';
+}
+
+/**
  * Determine if the module being processed is a gha-* repository e.g. gha-ci
  *
  * Example usage:

--- a/funcs_utils.php
+++ b/funcs_utils.php
@@ -127,11 +127,15 @@ function extra_repositories()
  */
 function script_files($cmsMajor)
 {
-    if (!ctype_digit($cmsMajor)) {
-        $cmsMajor = "-$cmsMajor";
+    if ($cmsMajor === 'default-branch') {
+        $dir = 'scripts/default-branch';
+    } else {
+        if (!ctype_digit($cmsMajor)) {
+            $cmsMajor = "-$cmsMajor";
+        }
+        $scriptFiles = [];
+        $dir = "scripts/cms$cmsMajor";
     }
-    $scriptFiles = [];
-    $dir = "scripts/cms$cmsMajor";
     if (!file_exists($dir)) {
         warning("$dir does not exist, no CMS $cmsMajor specific scripts will be run");
         return $scriptFiles;
@@ -296,7 +300,7 @@ function output_repos_with_prs_created()
  *
  * Assumes that for each module there is only a single major version per cms-major version
  */
-function branch_to_checkout($branches, $currentBranch, $currentBranchCmsMajor, $cmsMajor, $branchOption)
+function branch_to_checkout($branches, $defaultBranch, $currentBranch, $currentBranchCmsMajor, $cmsMajor, $branchOption)
 {
     $offset = (int) $cmsMajor - (int) $currentBranchCmsMajor;
     $majorTarget = (int) $currentBranch + $offset;
@@ -304,6 +308,9 @@ function branch_to_checkout($branches, $currentBranch, $currentBranchCmsMajor, $
     usort($branches, 'version_compare');
     $branches = array_reverse($branches);
     switch ($branchOption) {
+        case 'github-default':
+            $branchToCheckout = $defaultBranch;
+            break;
         case 'next-patch':
             $branchToCheckout = array_values(array_filter(
                 $branches,

--- a/run.php
+++ b/run.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Input\InputOption;
 
 // consts
 const CURRENT_CMS_MAJOR = '5';
-const BRANCH_OPTIONS = ['next-minor', 'next-patch'];
+const BRANCH_OPTIONS = ['next-minor', 'next-patch', 'github-default'];
 const DEFAULT_BRANCH = 'next-patch';
 const DEFAULT_ACCOUNT = 'creative-commoners';
 const DATA_DIR = '_data';

--- a/scripts/default-branch/issue-pr-templates-docs.php
+++ b/scripts/default-branch/issue-pr-templates-docs.php
@@ -1,0 +1,106 @@
+<?php
+
+// The template used for pull requests
+$pullRequestTemplate = <<<EOT
+<!--
+  Thanks for contributing, you're awesome! ⭐
+
+  Please read https://docs.silverstripe.org/en/contributing/documentation/ if you haven't contributed to this project recently.
+-->
+## Description
+<!--
+  Please describe the changes you're making, and the reason for making them.
+  For visual fixes, please include tested browsers and screenshots.
+-->
+
+## Issues
+<!--
+  List all issues here that this pull request fixes/resolves.
+  If there is no issue already, create a new one! You must link your pull request to at least one issue.
+-->
+- #
+
+## Pull request checklist
+<!--
+  PLEASE check each of these to ensure you have done everything you need to do!
+  If there's something in this list you need help with, please ask so that we can assist you.
+-->
+- [ ] The target branch is correct
+    - See [branches and commit messages](https://docs.silverstripe.org/en/contributing/documentation#branches-and-commit-messages)
+- [ ] All commits are relevant to the purpose of the PR (e.g. no TODO comments, unrelated rewording/restructuring, or arbitrary changes)
+    - Small amounts of additional changes are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
+- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
+- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/documentation/)
+- [ ] The changes follow our [writing style guide](https://docs.silverstripe.org/en/contributing/documentation/#writing-style)
+- [ ] Code examples follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
+- [ ] CI is green
+EOT;
+
+// The template used when clicking "Open a blank issue"
+$defaultIssueTemplate = "<!-- Blank templates are for use by maintainers only! If you aren't a maintainer, please go back and pick one of the issue templates. -->";
+
+// Defines configuration for form-style issue templates
+$config = <<<EOT
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://docs.silverstripe.org/en/contributing/issues_and_bugs/#reporting-security-issues
+    about: ⚠️ We do not use GitHub issues to track security vulnerability reports. Click "open" on the right to see how to report security vulnerabilities.
+  - name: Support Question
+    url: https://www.silverstripe.org/community/
+    about: We use GitHub issues only to discuss bugs and new features. For support questions, please use one of the support options available in our community channels.
+EOT;
+
+// The template used for documentation issues
+$documentationIssueTemplate = <<<EOT
+# This will be in the developer-docs and user help repos only
+name: 📖 Documentation issue
+description: Report an issue regarding the documentation content
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We strongly encourage you to [submit a pull request](https://docs.silverstripe.org/en/contributing/documentation/) which resolves the issue.
+        Issues which are accompanied with a pull request are a lot more likely to be resolved quickly.
+  - type: textarea
+    id: pages-affected
+    attributes:
+      label: Pages affected
+      description: A list of links of pages which are affected by this issue
+      placeholder: |
+
+        - [Getting Started](https://docs.silverstripe.org/en/5/getting_started/)
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the problem you've found in the documentation
+    validations:
+      required: true
+  - type: checkboxes
+    id: validations
+    attributes:
+      label: Validations
+      description: "Before submitting the issue, please make sure you do the following:"
+      options:
+        - label: Check that there isn't already an issue that reports the same problem
+          required: true
+EOT;
+
+$files = [
+    '.github/PULL_REQUEST_TEMPLATE.md' => $pullRequestTemplate,
+    '.github/ISSUE_TEMPLATE.md' => $defaultIssueTemplate,
+    '.github/ISSUE_TEMPLATE/config.yml' => $config,
+    '.github/ISSUE_TEMPLATE/1_docs_issue.yml' => $documentationIssueTemplate,
+];
+
+// See issue-pr-templates.php for the non-docs equivalent
+if (!is_docs()) {
+    return;
+}
+
+foreach ($files as $path => $contents) {
+    write_file_even_if_exists($path, $contents);
+}

--- a/scripts/default-branch/issue-pr-templates.php
+++ b/scripts/default-branch/issue-pr-templates.php
@@ -1,0 +1,191 @@
+<?php
+
+// The template used for pull requests
+$pullRequestTemplate = <<<EOT
+<!--
+  Thanks for contributing, you're awesome! ⭐
+
+  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
+-->
+## Description
+<!--
+  Please describe expected and observed behaviour, and what you're fixing.
+  For visual fixes, please include tested browsers and screenshots.
+-->
+
+## Manual testing steps
+<!--
+  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
+  Note that this DOES NOT replace unit or end-to-end tests.
+-->
+
+## Issues
+<!--
+  List all issues here that this pull request fixes/resolves.
+  If there is no issue already, create a new one! You must link your pull request to at least one issue.
+-->
+- #
+
+## Pull request checklist
+<!--
+  PLEASE check each of these to ensure you have done everything you need to do!
+  If there's something in this list you need help with, please ask so that we can assist you.
+-->
+- [ ] The target branch is correct
+    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
+- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
+    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
+- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
+- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
+- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
+- [ ] This change is covered with tests (or tests aren't necessary for this change)
+- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
+- [ ] CI is green
+EOT;
+
+// The template used when clicking "Open a blank issue"
+$defaultIssueTemplate = "<!-- Blank templates are for use by maintainers only! If you aren't a maintainer, please go back and pick one of the issue templates. -->";
+
+// Defines configuration for form-style issue templates
+$config = <<<EOT
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability
+    url: https://docs.silverstripe.org/en/contributing/issues_and_bugs/#reporting-security-issues
+    about: ⚠️ We do not use GitHub issues to track security vulnerability reports. Click "open" on the right to see how to report security vulnerabilities.
+  - name: Support Question
+    url: https://www.silverstripe.org/community/
+    about: We use GitHub issues only to discuss bugs and new features. For support questions, please use one of the support options available in our community channels.
+EOT;
+
+// The template used for bug report issues
+$bugReportTemplate = <<<EOT
+name: 🪳 Bug Report
+description: Tell us if something isn't working the way it's supposed to
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We strongly encourage you to [submit a pull request](https://docs.silverstripe.org/en/contributing/code/) which fixes the issue.
+        Bug reports which are accompanied with a pull request are a lot more likely to be resolved quickly.
+  - type: input
+    id: affected-versions
+    attributes:
+      label: Module version(s) affected
+      description: |
+        What version of _this module_ have you reproduced this bug on?
+        Run `composer info` to see the specific version of each module installed in your project.
+        If you don't have access to that, check inside the help menu in the bottom left of the CMS.
+      placeholder: x.y.z
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the problem
+    validations:
+      required: true
+  - type: textarea
+    id: how-to-reproduce
+    attributes:
+      label: How to reproduce
+      description: |
+        ⚠️ This is the most important part of the report ⚠️
+        Without a way to easily reproduce your issue, there is little chance we will be able to help you and work on a fix.
+        - Please, take the time to show us some code and/or configuration that is needed for others to reproduce the problem easily.
+        - If the bug is too complex to reproduce with some short code samples, please reproduce it in a public repository and provide a link to the repository along with steps for setting up and reproducing the bug using that repository.
+        - If part of the bug includes an error or exception, please provide a full stack trace.
+        - If any user interaction is required to reproduce the bug, please add an ordered list of steps that are required to reproduce it.
+        - Be as clear as you can, but don't miss any steps out. Simply saying "create a page" is less useful than guiding us through the steps you're taking to create a page, for example.
+      placeholder: |
+
+        #### Code sample
+        ```php
+
+        ```
+
+        #### Reproduction steps
+        1.
+    validations:
+      required: true
+  - type: textarea
+    id: possible-solution
+    attributes:
+      label: Possible Solution
+      description: |
+        *Optional: only if you have suggestions on a fix/reason for the bug*
+        Please consider [submitting a pull request](https://docs.silverstripe.org/en/contributing/code/) with your solution! It helps get faster feedback and greatly increases the chance of the bug being fixed.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: "*Optional: any other context about the problem: log messages, screenshots, etc.*"
+  - type: checkboxes
+    id: validations
+    attributes:
+      label: Validations
+      description: "Before submitting the issue, please make sure you do the following:"
+      options:
+        - label: Check that there isn't already an issue that reports the same bug
+          required: true
+        - label: Double check that your reproduction steps work in a fresh installation of [`silverstripe/installer`](https://github.com/silverstripe/silverstripe-installer) (with any code examples you've provided)
+          required: true
+EOT;
+
+// The template used for feature request issues
+$featureRequestTemplate = <<<EOT
+name: 🚀 Feature Request
+description: Submit a feature request (but only if you're planning on implementing it)
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please only submit feature requests if you plan on implementing the feature yourself.
+        See the [contributing code documentation](https://docs.silverstripe.org/en/contributing/code/#make-or-find-a-github-issue) for more guidelines about submitting feature requests.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the new feature, and why it belongs in core
+    validations:
+      required: true
+  - type: textarea
+    id: more-info
+    attributes:
+      label: Additional context or points of discussion
+      description: |
+        *Optional: Any additional context, points of discussion, etc that might help validate and refine your idea*
+  - type: checkboxes
+    id: validations
+    attributes:
+      label: Validations
+      description: "Before submitting the issue, please confirm the following:"
+      options:
+        - label: You intend to implement the feature yourself
+          required: true
+        - label: You have read the [contributing guide](https://docs.silverstripe.org/en/contributing/code/)
+          required: true
+        - label: You strongly believe this feature should be in core, rather than being its own community module
+          required: true
+        - label: You have checked for existing issues or pull requests related to this feature (and didn't find any)
+          required: true
+EOT;
+
+$files = [
+    '.github/PULL_REQUEST_TEMPLATE.md' => $pullRequestTemplate,
+    '.github/ISSUE_TEMPLATE.md' => $defaultIssueTemplate,
+    '.github/ISSUE_TEMPLATE/config.yml' => $config,
+    '.github/ISSUE_TEMPLATE/1_bug_report.yml' => $bugReportTemplate,
+    '.github/ISSUE_TEMPLATE/2_feature_request.yml' => $featureRequestTemplate,
+];
+
+// See issue-pr-templates-docs.php for the docs equivalent
+if (is_docs()) {
+    return;
+}
+
+foreach ($files as $path => $contents) {
+    write_file_even_if_exists($path, $contents);
+}

--- a/tests/FuncsUtilsTest.php
+++ b/tests/FuncsUtilsTest.php
@@ -10,12 +10,13 @@ class FuncsUtilsTest extends TestCase
     public function testBranchToCheckout(
         $expected,
         $branches,
+        $defaultBranch,
         $currentBranch,
         $currentBranchCmsMajor,
         $cmsMajor,
         $branchOption
     ) {
-        $actual = branch_to_checkout($branches, $currentBranch, $currentBranchCmsMajor, $cmsMajor, $branchOption);
+        $actual = branch_to_checkout($branches, $defaultBranch, $currentBranch, $currentBranchCmsMajor, $cmsMajor, $branchOption);
         $this->assertSame($expected, $actual);
     }
 
@@ -23,13 +24,14 @@ class FuncsUtilsTest extends TestCase
     {
         $branches = ['1.5', '1.6', '1', '2.0', '2.1' , '2.2', '2', '3', 'pulls/2.3/something', 'random'];
         return [
-            ['2', $branches, '2', '5', '5', 'next-minor'],
-            ['2.2', $branches, '2', '5', '5', 'next-patch'],
-            ['1', $branches, '2', '5', '4', 'next-minor'],
-            ['1.6', $branches, '2', '5', '4', 'next-patch'],
-            ['2', $branches, '1', '4', '5', 'next-minor'],
-            ['2.2', $branches, '1', '4', '5', 'next-patch'],
-            ['3', $branches, '1', '4', '6', 'next-minor'],
+            ['2', $branches, '2', '2', '5', '5', 'next-minor'],
+            ['2.2', $branches, '2', '2', '5', '5', 'next-patch'],
+            ['1', $branches, '2', '2', '5', '4', 'next-minor'],
+            ['1.6', $branches, '2', '2', '5', '4', 'next-patch'],
+            ['2', $branches, '2', '1', '4', '5', 'next-minor'],
+            ['2.2', $branches, '2', '1', '4', '5', 'next-patch'],
+            ['3', $branches, '2', '1', '4', '6', 'next-minor'],
+            ['2', $branches, '2', '1', '4', '6', 'github-default'],
         ];
     }
 

--- a/update_command.php
+++ b/update_command.php
@@ -56,10 +56,14 @@ $updateCommand = function(InputInterface $input, OutputInterface $output): int {
     }
 
     // script files
-    $scriptFiles = array_merge(
-        script_files('any'),
-        script_files($cmsMajor),
-    );
+    if ($branchOption === 'github-default') {
+        $scriptFiles = script_files('default-branch');
+    } else {
+        $scriptFiles = array_merge(
+            script_files('any'),
+            script_files($cmsMajor),
+        );
+    }
 
     // clone repos & run scripts
     foreach ($modules as $module) {
@@ -138,6 +142,7 @@ $updateCommand = function(InputInterface $input, OutputInterface $output): int {
             $currentBranchCmsMajor = current_branch_cms_major();
             $branchToCheckout = branch_to_checkout(
                 $allBranches,
+                $defaultBranch,
                 $currentBranch,
                 $currentBranchCmsMajor,
                 $cmsMajor,
@@ -150,7 +155,7 @@ $updateCommand = function(InputInterface $input, OutputInterface $output): int {
         cmd("git checkout $branchToCheckout", $MODULE_DIR);
 
         // ensure that this branch actually supports the cmsMajor we're targetting
-        if (current_branch_cms_major() !== $cmsMajor) {
+        if ($branchOption !== 'github-default' && current_branch_cms_major() !== $cmsMajor) {
             error("Branch $branchToCheckout does not support CMS major version $cmsMajor");
         }
 
@@ -196,7 +201,7 @@ $updateCommand = function(InputInterface $input, OutputInterface $output): int {
         // force pushing for cases when doing update-prs
         // double make check we're on a branch that we are willing to force push
         $currentBranch = cmd('git rev-parse --abbrev-ref HEAD', $MODULE_DIR);
-        if (!preg_match('#^pulls/[0-9\.]+/module\-standardiser\-[0-9]{10}$#', $currentBranch)) {
+        if (!preg_match('#^pulls/([0-9\.]+|master|main)/module\-standardiser\-[0-9]{10}$#', $currentBranch)) {
             error("Branch $currentBranch is not a pull-request branch");
         }
         cmd("git push -f -u pr-remote $prBranch", $MODULE_DIR);


### PR DESCRIPTION
- Adds new `github-default` option for the `--branch` option
    - Only runs against the default branch, and only runs the scripts in the `default-branch` dir.
    - This is necessary because we don't control the default branch of some repos, and some of them are `master` or `main`, and some of them are for CMS 4 branches
- Adds new scripts for adding issue/PR templates for docs repos and for non-docs repos

## Issue
- https://github.com/silverstripe/.github/issues/79