### PR TITLE
FIX Init array, use $oldName, add REPOS_EXCLUDE, check if label exists before rename

### DIFF
--- a/funcs_utils.php
+++ b/funcs_utils.php
@@ -88,6 +88,7 @@ function extra_repositories()
     $importantRepos = [
         'silverstripe/markdown-php-codesniffer',
         'silverstripe/silverstripe-standards',
+        'silverstripe/.github',
     ];
     $modules = [];
     // iterating to page 10 will be enough to get all the repos well into the future

--- a/run.php
+++ b/run.php
@@ -24,6 +24,7 @@ const PR_DESCRIPTION = 'This pull-request was created automatically by [module-s
 $MODULE_DIR = '';
 $PRS_CREATED = [];
 $REPOS_WITH_PRS_CREATED = [];
+$REPOS_WITH_LABELS_UPDATED = [];
 $OUT = null;
 
 // options


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/154

Need to init the array to prevent an error if no repos were matched using --only / --exclude falgs

Use $oldName so that the correct URL is used when rewriting an old label

Add REPOS_EXCLUDE which has some repos that should never have their labels updated