### PR TITLE
NEW Add script for setting phpstan config

### DIFF
--- a/funcs_scripts.php
+++ b/funcs_scripts.php
@@ -5,6 +5,22 @@ use Panlatent\CronExpressionDescriptor\ExpressionDescriptor;
 // These functions in scripts can be used in scripts
 
 /**
+ * Check that a directory exists relative to the root of the module being processed
+ *
+ * Example usage:
+ * check_dir_exists('src')
+ */
+function check_dir_exists($dirname) {
+    global $MODULE_DIR;
+    $path = "$MODULE_DIR/$dirname";
+    if (!is_dir($path)) {
+        info("Directory $path does not exist, though this should be OK");
+        return false;
+    }
+    return true;
+}
+
+/**
  * Check that a file exists relative to the root of the module being processed
  *
  * Example usage:
@@ -130,6 +146,28 @@ function is_module()
         && strpos($MODULE_DIR, '/vendor-plugin') === false
         && strpos($MODULE_DIR, '/eslint-config') === false
         && strpos($MODULE_DIR, '/webpack-config') === false;
+}
+
+/**
+ * Determine if the module being processed is a theme
+ *
+ * Example usage:
+ * is_theme()
+ */
+function is_theme()
+{
+    if (!check_file_exists('composer.json')) {
+        return false;
+    }
+
+    $contents = read_file('composer.json');
+    $json = json_decode($contents);
+    if (is_null($json)) {
+        $lastError = json_last_error();
+        error("Could not parse from composer.json - last error was $lastError");
+    }
+
+    return $json->type === 'silverstripe-theme';
 }
 
 /**

--- a/scripts/cms5/phpstan.php
+++ b/scripts/cms5/phpstan.php
@@ -1,0 +1,50 @@
+<?php
+
+// Only valid for non-theme modules
+if (!is_module() || is_theme()) {
+    return;
+}
+
+// Get the dirs we want to run static analysis against
+$dirs = [];
+foreach (['code', 'src', 'app/src'] as $codeDir) {
+    if (check_dir_exists($codeDir)) {
+        $dirs[] = $codeDir;
+    }
+}
+
+// If we have some dirs to run against, we don't need to do anything.
+if (empty($dirs)) {
+    return;
+}
+
+$content = <<<EOT
+parameters:
+  paths:
+    - %s
+
+EOT;
+
+// Create a phpstan config file
+write_file_even_if_exists('phpstan.neon.dist', sprintf($content, implode("\n    - ", $dirs)));
+
+// Add composer dependencies.
+// composer.json file is already guaranteed to exist - it's used in the is_module()/is_theme() checks above.
+// Do not add allow-plugins config - we don't want to be enforcing that for peoples' projects
+$contents = read_file('composer.json');
+$json = json_decode($contents, true);
+$jsonOrig = $json;
+if (!$json) {
+    warning('Failed to parse composer.json');
+} else {
+    if (!array_key_exists('require-dev', $json)) {
+        $json['require-dev'] = [];
+    }
+    $json['require-dev']['silverstripe/standards'] ??= '^1';
+    $json['require-dev']['phpstan/extension-installer'] ??= '^1.3';
+
+    if ($json !== $jsonOrig) {
+        $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+        write_file_even_if_exists('composer.json', json_encode($json, $flags));
+    }
+}


### PR DESCRIPTION
This PR assumes https://github.com/silverstripe/module-standardiser/pull/32 is merged first, as that changes how `is_module()` works.

This PR does the following:
- Add new `is_theme()` function to determine if a module is specifically a theme
- Add new `check_dir_exists()` function to check if a directory exists or not
- Adds new `phpstan.php` script for CMS 5 projects
    - is only processed for modules which aren't themes
    - is only processed if one of the relevant directories exists
    - adds `phpstan.neon.dist` configuration file
    - adds `silverstripe/standards` and `phpstan/extension-installer` dev dependencies

## Issue
- https://github.com/silverstripe/.github/issues/171