### PR TITLE
ENH Restrict which repos get dispatch-ci

### DIFF
--- a/funcs_scripts.php
+++ b/funcs_scripts.php
@@ -134,7 +134,7 @@ function module_is_recipe()
         error("Could not parse from composer.json - last error was $lastError");
     }
 
-    return $json->type === 'silverstripe-recipe';
+    return $json->type ?? '' === 'silverstripe-recipe';
 }
 
 /**
@@ -167,7 +167,29 @@ function is_module()
         'silverstripe-recipe',
         'silverstripe-theme',
     ];
-    return in_array($json->type, $moduleTypes);
+    return in_array($json->type ?? '', $moduleTypes);
+}
+
+/**
+ * Determine if the module being processed is a composer plugin
+ *
+ * Example usage:
+ * is_composer_plugin()
+ */
+function is_composer_plugin()
+{
+    if (!check_file_exists('composer.json')) {
+        return false;
+    }
+
+    $contents = read_file('composer.json');
+    $json = json_decode($contents);
+    if (is_null($json)) {
+        $lastError = json_last_error();
+        error("Could not parse from composer.json - last error was $lastError");
+    }
+
+    return $json->type ?? '' === 'composer-plugin';
 }
 
 /**
@@ -190,6 +212,15 @@ function is_theme()
     }
 
     return $json->type === 'silverstripe-theme';
+}
+
+/**
+ * Determine if the module being processed is a meta repository
+ */
+function is_meta_repo()
+{
+    $moduleName = module_name();
+    return $moduleName === '.github';
 }
 
 /**

--- a/scripts/cms-any/dispatch-ci.php
+++ b/scripts/cms-any/dispatch-ci.php
@@ -32,6 +32,14 @@ jobs:
         uses: silverstripe/gha-dispatch-ci@v1
 EOT;
 
-if (check_file_exists('.github/workflows/ci.yml')) {
-    write_file_even_if_exists('.github/workflows/dispatch-ci.yml', $content);
+$dispatchCiPath = '.github/workflows/dispatch-ci.yml';
+$ciPath = '.github/workflows/ci.yml';
+$shouldHaveDispatchCi = (is_module() || is_composer_plugin()) && !is_docs() && !is_gha_repository();
+
+if ($shouldHaveDispatchCi) {
+  if (check_file_exists($ciPath)) {
+    write_file_even_if_exists($dispatchCiPath, $content);
+  }
+} else {
+  delete_file_if_exists($dispatchCiPath);
 }

--- a/scripts/cms-any/license.php
+++ b/scripts/cms-any/license.php
@@ -41,8 +41,8 @@ $licenseFilename = 'LICENSE';
 foreach (['LICENSE.md', 'license.md', 'license'] as $filename) {
     rename_file_if_exists($filename, $licenseFilename);
 }
-// only update licence contents if module is on silverstripe account
-if (module_account() === 'silverstripe') {
+// only update licence contents if module is on silverstripe account and is not a meta repo
+if (module_account() === 'silverstripe' && !is_meta_repo()) {
     if (check_file_exists($licenseFilename)) {
         $oldContents = read_file($licenseFilename);
         $newContents = str_replace('SilverStripe', 'Silverstripe', $oldContents);

--- a/scripts/cms-any/merge-ups.php
+++ b/scripts/cms-any/merge-ups.php
@@ -54,6 +54,6 @@ if (check_file_exists('.github/workflows/merge-ups.yml')) {
     rename_file_if_exists('.github/workflows/merge-ups.yml', '.github/workflows/merge-up.yml');
 }
 
-if (!module_is_recipe()) {
+if (!module_is_recipe() && !is_meta_repo()) {
   write_file_even_if_exists('.github/workflows/merge-up.yml', $content);
 }


### PR DESCRIPTION
Issue https://github.com/silverstripe/module-standardiser/issues/37

Note I ended up putting in some checking for is_meta_repo() aka .github repo which recently was added, this is required otherwise you cannot do a full dry-run

We want still want dispatch-ci on composer-plugins() specifically for vendor-plugin() which integrates with other things - https://github.com/silverstripe/vendor-plugin/actions/runs/7871071271

recipe-plugin() only does linting, so it's a bit pointless being on a cron like this though it's cleaner to just keep it on dispatch-ci - https://github.com/silverstripe/recipe-plugin/actions/runs/7854707347

should_use_dispatch_ci() will return as follows for the repos:

```
[0] => yes: silverstripe-maintenance
[1] => yes: silverstripe-composer-update-checker
[2] => yes: GridFieldBulkEditingTools
[3] => yes: cwp-agencyextensions
[4] => yes: cwp-starter-theme
[5] => no : developer-docs
[6] => yes: cwp-watea-theme
[7] => yes: silverstripe-elemental
[8] => yes: silverstripe-elemental-userforms
[9] => yes: silverstripe-admin
[10] => yes: silverstripe-asset-admin
[11] => yes: silverstripe-assets
[12] => yes: silverstripe-auditor
[13] => yes: silverstripe-blog
[14] => yes: silverstripe-campaign-admin
[15] => yes: silverstripe-cms
[16] => yes: silverstripe-config
[17] => yes: silverstripe-contentreview
[18] => yes: silverstripe-crontask
[19] => yes: silverstripe-documentconverter
[20] => yes: silverstripe-elemental-bannerblock
[21] => yes: silverstripe-elemental-fileblock
[22] => yes: silverstripe-environmentcheck
[23] => yes: silverstripe-errorpage
[24] => no : eslint-config
[25] => yes: silverstripe-externallinks
[26] => yes: silverstripe-framework
[27] => yes: silverstripe-graphql
[28] => yes: silverstripe-gridfieldqueuedexport
[29] => yes: silverstripe-hybridsessions
[30] => yes: silverstripe-iframe
[31] => yes: silverstripe-installer
[32] => yes: silverstripe-ldap
[33] => yes: silverstripe-linkfield
[34] => yes: silverstripe-lumberjack
[35] => yes: silverstripe-mimevalidator
[36] => yes: silverstripe-realme
[37] => yes: silverstripe-session-manager
[38] => yes: recipe-authoring-tools
[39] => yes: recipe-blog
[40] => yes: recipe-cms
[41] => yes: recipe-collaboration
[42] => yes: recipe-content-blocks
[43] => yes: recipe-core
[44] => yes: recipe-form-building
[45] => yes: recipe-plugin
[46] => yes: recipe-reporting-tools
[47] => yes: recipe-services
[48] => yes: silverstripe-registry
[49] => yes: silverstripe-reports
[50] => yes: silverstripe-restfulserver
[51] => yes: silverstripe-securityreport
[52] => yes: silverstripe-segment-field
[53] => yes: silverstripe-sharedraftcontent
[54] => yes: silverstripe-siteconfig
[55] => yes: silverstripe-sitewidecontent-report
[56] => yes: silverstripe-spamprotection
[57] => yes: silverstripe-staticpublishqueue
[58] => yes: silverstripe-subsites
[59] => yes: silverstripe-tagfield
[60] => yes: silverstripe-taxonomy
[61] => yes: silverstripe-textextraction
[62] => yes: silverstripe-userforms
[63] => yes: vendor-plugin
[64] => yes: silverstripe-versioned
[65] => yes: silverstripe-versioned-admin
[66] => yes: silverstripe-versionfeed
[67] => no : webpack-config
[68] => yes: silverstripe-simple
[69] => yes: silverstripe-advancedworkflow
[70] => yes: silverstripe-gridfieldextensions
[71] => yes: silverstripe-multivaluefield
[72] => yes: silverstripe-queuedjobs
[73] => yes: silverstripe-fluent
[74] => yes: silverstripe-mfa
[75] => yes: silverstripe-totp-authenticator
[76] => yes: silverstripe-webauthn-authenticator
[77] => yes: silverstripe-login-forms
[78] => yes: silverstripe-dynamodb
[79] => no : gha-ci
[80] => no : gha-run-tests
[81] => no : gha-generate-matrix
[82] => no : gha-auto-tag
[83] => no : gha-pull-request
[84] => no : gha-tag-release
[85] => no : gha-update-js
[86] => no : gha-keepalive
[87] => no : .github
[88] => no : gha-dispatch-ci
[89] => no : gha-issue
[90] => no : gha-merge-up
[91] => no : gha-action-ci
[92] => no : gha-gauge-release
[93] => no : gha-trigger-ci
[94] => no : markdown-php-codesniffer
[95] => no : silverstripe-standards
```