### PR TITLE
FIX Add brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ MS_GITHUB_TOKEN=abc123 php run.php update --cms-major=5 --branch=next-minor --dr
 | --exclude=[modules] | Exclude the specified modules (without account prefix) separated by commas e.g. `silverstripe-mfa,silverstripe-totp` |
 | --dry-run | Do not push to github or create pull-requests |
 | --account | GitHub account to use for creating pull-requests (default: creative-commoners) |
-| --no-delete | Do not delete `_data` and `modules` directories before running |
+| --no-delete | Do not delete `_data` and `_modules` directories before running |
 | --update-prs | Update existing open PRs instead of creating new PRs |
 
 **Note** that using `--branch=github-default` will only run scripts in the `scripts/default-branch` directory.

--- a/funcs_scripts.php
+++ b/funcs_scripts.php
@@ -135,7 +135,7 @@ function module_is_recipe()
         error("Could not parse from composer.json - last error was $lastError");
     }
 
-    return $json->type ?? '' === 'silverstripe-recipe';
+    return ($json->type ?? '') === 'silverstripe-recipe';
 }
 
 /**
@@ -190,7 +190,7 @@ function is_composer_plugin()
         error("Could not parse from composer.json - last error was $lastError");
     }
 
-    return $json->type ?? '' === 'composer-plugin';
+    return ($json->type ?? '') === 'composer-plugin';
 }
 
 /**

--- a/funcs_utils.php
+++ b/funcs_utils.php
@@ -50,6 +50,7 @@ function write_file($path, $contents)
 
 /**
  * Returns a list of all scripts files to run against a particular cms major version
+ * Scripts will be alphabetically sorted
  */
 function script_files($cmsMajor)
 {
@@ -78,6 +79,7 @@ function script_files($cmsMajor)
         }
         closedir($handle);
     }
+    sort($scriptFiles);
     return $scriptFiles;
 }
 


### PR DESCRIPTION
Turns out you need brackets in this scenario, won't return a bool, instead it returns the value of the property

```
$o = new stdClass;
$o->abc=123;
var_dump($o->abc ?? '' === 'def');
// int(123)
```

Also alpha sorts script files so that scripts run in a predictable nature - this is desirable because there's a depedency on dispatch-ci.yml from merge-ups.yml - https://github.com/silverstripe/module-standardiser/blob/main/scripts/cms-any/merge-ups.php#L10