### PR TITLE
ENH Remove restrict creations rule for tag ruleset

### DIFF
--- a/rulesets/tag-ruleset.json
+++ b/rulesets/tag-ruleset.json
@@ -18,9 +18,6 @@
       "type": "non_fast_forward"
     },
     {
-      "type": "creation"
-    },
-    {
       "type": "update"
     }
   ],

--- a/rulesets_command.php
+++ b/rulesets_command.php
@@ -67,8 +67,10 @@ $rulesetsCommand = function(InputInterface $input, OutputInterface $output): int
         // Note: This will read from the "rulesets" directory
         // In each of those json rulesets there is "bypass_actors"."actor_id" = 5
         // This translates to the "Repository admin" role
-        // It has been confirmed that the github-action user is able to bypass the ruleset as
-        // it has the "Organisation admin" role which is one level above the "Repository admin" role
+        //
+        // Note that the github-action user appears to have NO bypass permissions (not even write),
+        // even if it has the `contents: write` permission on the job that is running the action
+        //
         $branchRuleset = create_ruleset('branch', $additionalBranchConditions);
         $tagRuleset = create_ruleset('tag');
 

--- a/run.php
+++ b/run.php
@@ -20,6 +20,9 @@ const MODULES_DIR = '_modules';
 const TOOL_URL = 'https://github.com/silverstripe/module-standardiser';
 const PR_TITLE = 'MNT Run module-standardiser';
 const PR_DESCRIPTION = 'This pull-request was created automatically by [module-standardiser](' . TOOL_URL . ')';
+
+// DO NOT change these constants or else new ruleset will be created instead of
+// updating existing rulesets and we'll end up with 2x rulesets
 const BRANCH_RULESET_NAME = 'Silverstripe CMS branch ruleset';
 const TAG_RULESET_NAME = 'Silverstripe CMS tag ruleset';
 


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/259

Assign back to Steve after merge to run module-standardiser to update tag rulesets

Once those have been updated also trigger new CI runs on patch branches for elemental + framework to confirm patch releases happen