### PR TITLE
FIX Loosen ruleset to allow gha-merge-ups workflow to function

### DIFF
--- a/rulesets/branch-ruleset.json
+++ b/rulesets/branch-ruleset.json
@@ -19,19 +19,6 @@
     },
     {
       "type": "creation"
-    },
-    {
-      "type": "update"
-    },
-    {
-      "type": "pull_request",
-      "parameters": {
-        "required_approving_review_count": 2,
-        "dismiss_stale_reviews_on_push": true,
-        "require_code_owner_review": false,
-        "require_last_push_approval": true,
-        "required_review_thread_resolution": false
-      }
     }
   ],
   "bypass_actors": [


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/264

I tested it on the silverstripe-blog repo and running the merge-ups workflow. It needs both the "Restrict updates" and "Require a pull request before merging" checkboxes unticked in order to function
