### PR TITLE
FIX Loosen tag ruleset to allow gha-auto-tag to work

### DIFF
--- a/rulesets/tag-ruleset.json
+++ b/rulesets/tag-ruleset.json
@@ -12,9 +12,6 @@
   },
   "rules": [
     {
-      "type": "deletion"
-    },
-    {
       "type": "non_fast_forward"
     },
     {


### PR DESCRIPTION
Issue https://github.com/silverstripe/.github/issues/267

Tested be unticking the "Restrict deletions" rule on gha-dispatch-ci and manually running the auto-tag workflow
