### PR TITLE
NEW Add script for new action that adds PRs to project

### DIFF
--- a/scripts/cms-any/add-prs-to-project.php
+++ b/scripts/cms-any/add-prs-to-project.php
@@ -1,0 +1,31 @@
+<?php
+
+$content = <<<EOT
+name: Add new pull requests to a github project
+
+on:
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+
+permissions: {}
+
+jobs:
+  addprtoproject:
+    # Only run on the silverstripe account
+    if: github.repository_owner == 'silverstripe'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add PR to github project
+        uses: silverstripe/add-pr-to-project@v1
+EOT;
+
+$actionPath = '.github/workflows/add-prs-to-project.yml';
+$shouldHaveAction = module_account() === 'silverstripe' && is_module() && !module_is_recipe();
+
+if ($shouldHaveAction) {
+    write_file_even_if_exists($actionPath, $content);
+} else {
+    delete_file_if_exists($actionPath);
+}


### PR DESCRIPTION
New action for non-recipe modules which adds all new PRs (which aren't created by CMS Squad) to the new Community Contributions project.

Doesn't run on non-silverstripe repos because we can't add random users with write-access to those - so no point even showing them on the board.

## Issues
- https://github.com/silverstripe/.github/issues/155