### PR TITLE
FIX Don't try to use option when it doesn't exist

### DIFF
--- a/funcs_utils.php
+++ b/funcs_utils.php
@@ -380,7 +380,7 @@ function filtered_modules($cmsMajor, $input)
         $cmsMajor === MetaData::HIGHEST_STABLE_CMS_MAJOR
     );
 
-    if ($input->getOption('unsupported-default-branch')) {
+    if ($input->hasOption('unsupported-default-branch') && $input->getOption('unsupported-default-branch')) {
         $prevCmsMajor = $cmsMajor - 1;
         $prevCmsRepos = MetaData::removeReposNotInCmsMajor(
             MetaData::getAllRepositoryMetaData(false),


### PR DESCRIPTION
When running this command:

```sh
MS_GITHUB_TOKEN=my_token php run.php labels --only=gha-add-pr-to-project
```

I got the following error:

> The "unsupported-default-branch" option does not exist.

## Issue
- https://github.com/silverstripe/.github/issues/155