### PR TITLE
FIX Add gha- prefix to name of gha repo

### DIFF
--- a/scripts/cms-any/add-prs-to-project.php
+++ b/scripts/cms-any/add-prs-to-project.php
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add PR to github project
-        uses: silverstripe/add-pr-to-project@v1
+        uses: silverstripe/gha-add-pr-to-project@v1
 EOT;
 
 $actionPath = '.github/workflows/add-prs-to-project.yml';


### PR DESCRIPTION
Accidentally missed off the `gha-` part of the repo name in the new action, so it's failing in all the PRs.

## Issue
- https://github.com/silverstripe/.github/issues/155