### PR TITLE
Fix various problems (multiple commits)

### DIFF
--- a/funcs_scripts.php
+++ b/funcs_scripts.php
@@ -241,6 +241,24 @@ function is_docs()
 }
 
 /**
+ * Determine if the module being processed is commercially supported
+ *
+ * Example usage:
+ * is_supported()
+ */
+function is_supported()
+{
+    global $GITHUB_REF;
+    return in_array(
+        $GITHUB_REF,
+        array_column(
+            MetaData::getAllRepositoryMetaData()[MetaData::CATEGORY_SUPPORTED],
+            'github'
+        )
+    );
+}
+
+/**
  * Determine if the module being processed is a gha-* repository e.g. gha-ci
  * aka "WORKFLOW"
  *
@@ -263,7 +281,7 @@ function is_gha_repository()
  * Determine if the module being processed is "TOOLING"
  *
  * Example usage:
- * is_gha_repository()
+ * is_tooling()
  */
 function is_tooling()
 {
@@ -281,7 +299,7 @@ function is_tooling()
  * Determine if the module being processed is "MISC"
  *
  * Example usage:
- * is_gha_repository()
+ * is_misc()
  */
 function is_misc()
 {

--- a/scripts/cms-any/add-prs-to-project.php
+++ b/scripts/cms-any/add-prs-to-project.php
@@ -1,6 +1,6 @@
 <?php
 
-$content = <<<EOT
+$content = <<<'EOT'
 name: Add new pull requests to a github project
 
 on:

--- a/scripts/cms-any/add-prs-to-project.php
+++ b/scripts/cms-any/add-prs-to-project.php
@@ -25,7 +25,7 @@ jobs:
 EOT;
 
 $actionPath = '.github/workflows/add-prs-to-project.yml';
-$shouldHaveAction = module_account() === 'silverstripe' && is_module() && !module_is_recipe();
+$shouldHaveAction = module_account() === 'silverstripe' && is_supported() && is_docs() || (is_module() && !module_is_recipe());
 
 if ($shouldHaveAction) {
     write_file_even_if_exists($actionPath, $content);


### PR DESCRIPTION
Fixes various problems I found while running the standardiser:

1. There was a syntax error using a heredoc instead of a nowdoc (`${` was interpreted as being for string interpolation, though it should just be included as-is)
2. New action was being added to a couple items that aren't supported (e.g. frameworktest), and _wasn't_ being added to docs
3. Processing was interrupted to tell me that frameworktest and a couple of other repos don't have a next-patch branch. That should just be a warning at the end, instead.

## Issue
- https://github.com/silverstripe/.github/issues/155