### PR TITLE
FIX Don't try to tag patches on recipes

### DIFF
--- a/scripts/cms-any/tag-patch-release.php
+++ b/scripts/cms-any/tag-patch-release.php
@@ -65,7 +65,7 @@ $notAllowedRepos = [
     'silverstripe-tx-translator',
     'supported-modules',
 ];
-$shouldHaveAction = $shouldHaveAction && !is_misc() && !module_is_one_of($notAllowedRepos);
+$shouldHaveAction = $shouldHaveAction && !is_misc() && !module_is_recipe() && !module_is_one_of($notAllowedRepos);
 
 if ($shouldHaveAction) {
   write_file_even_if_exists($workflowPath, $content);


### PR DESCRIPTION
Fixes https://github.com/silverstripe/recipe-cms/actions/runs/11061574043/job/30735647831 (and similar failures on other recipes)
> Workflow does not have 'workflow_dispatch' trigger

We shouldn't be trying to tag patches on recipes _at all_. Recipe tags are _always_ done explicitly and deliberately.

## Issue
- https://github.com/silverstripe/.github/issues/313