### PR TITLE
FIX Allow tag-patch-release for tx-translator

### DIFF
--- a/scripts/cms-any/tag-patch-release.php
+++ b/scripts/cms-any/tag-patch-release.php
@@ -62,7 +62,6 @@ $notAllowedRepos = [
     'rhino',
     'github-issue-search-client',
     'module-standardiser',
-    'silverstripe-tx-translator',
     'supported-modules',
 ];
 $shouldHaveAction = $shouldHaveAction && !is_misc() && !module_is_recipe() && !module_is_one_of($notAllowedRepos);


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-tx-translator/issues/36

We had tx-translator excluded from getting tag-patch-release, though I think this is incorrect, as unlike other things in that list, it's composer required