### PR TITLE
ENH Add ci.php script

### DIFF
--- a/scripts/cms-any/ci.php
+++ b/scripts/cms-any/ci.php
@@ -1,0 +1,22 @@
+<?php
+
+// ci.yml files have been historically manually added to repos rather than using module standardiser
+
+// Update the ci.yml to include additional conditions for pull-request handling
+// This is to prevent the CI from running on pull-requests from the same repo
+
+$one = "    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1";
+$two = implode("\n", [
+  "    # Do not run if this is a pull-request from same repo i.e. not a fork repo" ,
+  "    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository"
+]);
+
+$ciPath = '.github/workflows/ci.yml';
+if (check_file_exists($ciPath)) {
+  $contents = read_file($ciPath);
+  if (str_contains($contents, $one) && !str_contains($contents, $two)) {
+    $three = $two . "\n" . $one;
+    $contents = str_replace($one, $three, $contents);
+    write_file_even_if_exists($ciPath, $contents);
+  }
+}


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-ci/issues/161

I'm fairly sure that we need to let the push event triggered job run, and prevent the pull_request job from running, rather than the other way around. This is because the push job has no context that there's also a pull-request.  We couldn't even do this with an API call to the report to check because the pull-request job may not even be triggered for several minutes after the push event if someone is filling in the textarea about the PR in the github gui

~I've filtered the logic to only check if the account starts with 'silverstripe', because other outside of this org who use the github ci workflow may have their own process where they do in fact want to do PRs to their own fork from the fork, and that's perfectly fine.  There is logic in the gha-ci that will find the version of installer to use based on the branch name and it expects a pattern `pulls/5/something`, if it does not match that then push job (but not the pull_request job) will fail. While we are very consistent with this branch naming pattern, others will not consistently follow it. Therefore we need to keep both jobs running for that scenario.~ **Update - not doing**

I've gone with a module-standardiser approach to update all ci.yml in all repos [example](https://github.com/silverstripe/silverstripe-framework/blob/5/.github/workflows/ci.yml), rather than update the [shared ci.yml workflow](https://github.com/silverstripe/gha-ci/blob/1/.github/workflows/ci.yml) because the "user experience" will be slightly better as it'll show up as a skipped job, rather than a job that goes green, though just happens to not actually run any tests which won't be apparent unless you clicked in to view details of the run

e.g. testing on my personal fork - you can see that the push job still runs, though the pull_request job is skipped

![image](https://github.com/user-attachments/assets/01c173ae-4fa6-4af1-9607-fee04b924e89)






